### PR TITLE
Add game state to drone prompt

### DIFF
--- a/multiscapes/domain/DroneResponseGenerator.js
+++ b/multiscapes/domain/DroneResponseGenerator.js
@@ -265,13 +265,13 @@ ${isBarrierOpen ?
             const json = JSON.stringify(gameState ?? {}, null, 2);
             return `
 
-# ESTADO DEL JUEGO (JSON)
+# GAME_STATE_JSON
 ${json}
 `;
         } catch (error) {
             return `
 
-# ESTADO DEL JUEGO (JSON)
+# GAME_STATE_JSON
 {"error": "No se pudo serializar el estado del juego"}
 `;
         }

--- a/multiscapes/infrastructure/GameStateService.js
+++ b/multiscapes/infrastructure/GameStateService.js
@@ -52,10 +52,11 @@ class GameStateService {
             const doc = await docRef.get();
             
             if (doc.exists) {
-                const data = doc.data();
+                const data = doc.data() || {};
                 return {
-                    barreraElectromagneticaAbierta: data.barreraElectromagneticaAbierta || false,
-                    start: data.start || "1"
+                    ...data,
+                    barreraElectromagneticaAbierta: data.barreraElectromagneticaAbierta ?? false,
+                    start: data.start ?? "1"
                 };
             } else {
                 // Estado por defecto


### PR DESCRIPTION
Adds the current game state from Firestore as a JSON block to the drone's system prompt.

The game state is fetched from `twin-island/codigo-del-juego` and included in the prompt under a `# GAME_STATE_JSON` heading, allowing the drone to use the full game context. `GameStateService` was updated to return all document fields.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e8ee120-2a0e-4a22-97f7-35c7b980b315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e8ee120-2a0e-4a22-97f7-35c7b980b315">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

