### PR TITLE
Inicializar dron en playa-sur al resetear

### DIFF
--- a/multiscapes/infrastructure/GameResetService.js
+++ b/multiscapes/infrastructure/GameResetService.js
@@ -73,7 +73,8 @@ class GameResetService {
                 barreraElectromagneticaAbierta: false,
                 start: "1",
                 createdAt: new Date().toISOString(),
-                resetAt: new Date().toISOString()
+                resetAt: new Date().toISOString(),
+                currentRoom: "playa-sur"
             };
             
             await docRef.set(initialData);


### PR DESCRIPTION
Add `currentRoom: "playa-sur"` to the initial game state on reset to ensure the drone starts in that room.

---
<a href="https://cursor.com/background-agent?bcId=bc-92dbcfac-ac40-46f5-9956-320987d7a132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-92dbcfac-ac40-46f5-9956-320987d7a132">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

